### PR TITLE
The supported Chef version is `>= 12.4`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ this cookbook uses [Ruby monkey patching](http://stackoverflow.com/questions/394
 It checks for the existance of a new configuration option: `Chef::Config[:live_stream]`, which is set by default in this cookbook
 
 # Version compatibility
-The current version (1.0.0) is compatible with Chef 12.1.0+ as far as I know.   The previous version (0.1.0) was compatible with Chef 11 and Chef 12.0.x
+The current version (1.0.0) is compatible with Chef 12.4.0+ as far as I know. The previous version (0.1.0) was compatible with Chef 11 and Chef 12.0.x

--- a/libraries/fancy_execute_provider.rb
+++ b/libraries/fancy_execute_provider.rb
@@ -23,7 +23,7 @@ class Chef
   class Provider
     class FancyExecute < Chef::Provider::Execute
 
-      # this code will only work with Chef 12.1+
+      # this code will only work with Chef 12.4+
       provides :execute, override: true
 
       # force this to on if not set

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,4 +6,4 @@ description      'Overrides the execute resource to force live_streaming of outp
 long_description 'Overrides the execute resource to force live_streaming of output'
 source_url       'https://github.com/irvingpop/fancy_execute'
 issues_url       'https://github.com/irvingpop/fancy_execute/issues'
-version          '1.0.0'
+version          '1.0.1'


### PR DESCRIPTION
The `:override` option shipped as part of Chef 12.4.0:
https://github.com/chef/chef/commit/db59fd9392a97328df8d7ba7f1c2b1fc03058e76#diff-8934ade575fb0e8c0b16e545b51aef5cR53

/cc @irvingpop 
